### PR TITLE
Allow embedding precompiled dict when building exe app

### DIFF
--- a/jamdict/config.py
+++ b/jamdict/config.py
@@ -76,7 +76,7 @@ def read_config():
 
 def home_dir():
     _config = read_config()
-    return _config.get('JAMDICT_HOME', '.')
+    return _config.get('JAMDICT_HOME', __jamdict_home)
 
 
 def data_dir():


### PR DESCRIPTION
Hi,
First of all let me say that i'm not much into python, so let me know if i'm missing or misunderstand something.

I'm building an exe application for windows using this module, since i don't want python as a requirement i wanted to ship the precompiled dictionary with the application.
I could copy .jamdict during the installation, but i thought it would be better for it to be inside the bundle.

I saw that config.py tries to search for db in different directories, starting with the \_\_file\_\_ directory. So if i create a jamdict/ directory with jamdict.json in the folder of the executable program, it actually reads it for searching db files.
Problem is that JAMDICT_HOME is ~/.jamdict by default, and if remove it i falls back to current directory folder ('.'). So it can't find the dbs.

I think JAMDICT_HOME should be fallbacking to __jamdict_home, since this is the path actually used to search for jamdict.json (as alternative to ~/.jamdict).
Using this code i can bundle the precompiled dictionary successfully.