### PR TITLE
Add empty line between Characters in lookup

### DIFF
--- a/jamdict/tools.py
+++ b/jamdict/tools.py
@@ -142,6 +142,7 @@ def dump_result(results, report=None):
             for rmg in c.rm_groups:
                 report.print("Readings:", ", ".join([r.value for r in rmg.readings]))
                 report.print("Meanings:", ", ".join([m.value for m in rmg.meanings if not m.m_lang or m.m_lang == 'en']))
+            report.print('')
         report.print('')
     else:
         report.print("No character was found.")


### PR DESCRIPTION
Hello!

I'm unaware of what consequences this small change might have for other parts of the program, or other programs that could be expecting the input in a certain format.

I added a line to `dump_results` to add some space between each character found - this way I think it also matches the rest of the information's formatting.

So now, when running `python3 -m jamdict.tools lookup 言語学` I get
```
========================================
Found entries
========================================
Entry: 1264430 | Kj:  言語学 | Kn: げんごがく
--------------------
1. linguistics ((noun (common) (futsuumeishi)))

========================================
Found characters
========================================
Char: 言 | Strokes: 7
--------------------
Readings: yan2, eon, 언, Ngôn, Ngân, ゲン, ゴン, い.う, こと
Meanings: say, word

Char: 語 | Strokes: 14
--------------------
Readings: yu3, yu4, eo, 어, Ngữ, Ngứ, ゴ, かた.る, かた.らう
Meanings: word, speech, language

Char: 学 | Strokes: 8
--------------------
Readings: xue2, hag, 학, Học, ガク, まな.ぶ
Meanings: study, learning, science


No name was found.
```

Instead of getting:
```
========================================
Found entries
========================================
Entry: 1264430 | Kj:  言語学 | Kn: げんごがく
--------------------
1. linguistics ((noun (common) (futsuumeishi)))

========================================
Found characters
========================================
Char: 言 | Strokes: 7
--------------------
Readings: yan2, eon, 언, Ngôn, Ngân, ゲン, ゴン, い.う, こと
Meanings: say, word
Char: 語 | Strokes: 14
--------------------
Readings: yu3, yu4, eo, 어, Ngữ, Ngứ, ゴ, かた.る, かた.らう
Meanings: word, speech, language
Char: 学 | Strokes: 8
--------------------
Readings: xue2, hag, 학, Học, ガク, まな.ぶ
Meanings: study, learning, science

No name was found.
```

Again, this could have more implications that I know, but I made the small change for myself and thought of submitting this pull request.

Thank you,
~romes